### PR TITLE
chore(docker): increase node version to 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:14-alpine As base
+FROM node:16-alpine As base
 LABEL vendor="Tributech.io Solutions"
 WORKDIR /app
 
-FROM node:14-alpine As build
+FROM node:16-alpine As build
 
 WORKDIR /app
 


### PR DESCRIPTION
We are using some features that are not available in Node v14, so we need to update to a higher version.